### PR TITLE
SubsonicDefaultProjectionAttribute proposal (possible fix for Issue 177)

### DIFF
--- a/SubSonic.Core/DataProviders/DbDataProvider.cs
+++ b/SubSonic.Core/DataProviders/DbDataProvider.cs
@@ -477,10 +477,16 @@ namespace SubSonic.DataProviders
 
             // TODO: Can we use Database.ToEnumerable here? -> See commit 654aa2f48a67ba537e34 that fixes some issues
             Type type = typeof (T);
+            
             //this is so hacky - the issue is that the Projector below uses Expression.Convert, which is a bottleneck
             //it's about 10x slower than our ToEnumerable. Our ToEnumerable, however, stumbles on Anon types and groupings
             //since it doesn't know how to instantiate them (I tried - not smart enough). So we do some trickery here.
-            if (type.Name.Contains("AnonymousType") || type.Name.StartsWith("Grouping`") || type.FullName.StartsWith("System.")) {
+
+            //hilton smith - added a check onto this if statement checking if the class is marked with the SubsonicDefaultProjectionAttribute
+            //i have been having trouble with some viewmodels where the property names don't line up with the column names.
+            //in order to get around this i added a new attribute type than can be applied to classes where the default linq projector is required
+
+            if (type.Name.Contains("AnonymousType") || type.Name.StartsWith("Grouping`") || type.FullName.StartsWith("System.") || type.GetCustomAttributes(typeof(SubsonicDefaultProjectionAttribute), false).Length > 0) {
                 var reader = ExecuteReader(cmd);
                 return Project(reader, query.Projector);
             } 

--- a/SubSonic.Core/SQLGeneration/Schema/SchemaAttributes.cs
+++ b/SubSonic.Core/SQLGeneration/Schema/SchemaAttributes.cs
@@ -174,4 +174,8 @@ namespace SubSonic.SqlGeneration.Schema
             column.DefaultSetting = DefaultSetting;
         }
     }
+
+    //hilton smith - i added this attribute, its used in DbDataProvider to see which projector gets used when filling a class
+    [AttributeUsage(AttributeTargets.Class)]
+    public class SubsonicDefaultProjectionAttribute : Attribute { }
 }


### PR DESCRIPTION
I have been having some trouble using custom viewmodels that are a combination of two or more tables. Often the viewmodel properties don't match up to the table column names and so the subsonic projector was having some trouble filling those objects.

I have added a new custom attribute called "SubsonicDefaultProjectionAttribute" in the SchemaAttributes class that targets classes. The thinking here is that if you have a class that needs to execute the default linq projection, you mark it with this attribute and it will bypass subsonics column name matching.

I also updated the if statement in DBDataProvider.cs to check for this attribute.

If I broke anything or its dumb please let me know so I can punch myself in the face.
Thanks.
