### PR TITLE
Update should support set to null

### DIFF
--- a/SubSonic.Core/Query/Update.cs
+++ b/SubSonic.Core/Query/Update.cs
@@ -311,6 +311,8 @@ namespace SubSonic.Query
                 LambdaExpression lamda = column;
                 Constraint c = lamda.ParseConstraint();
 
+                if (c.Comparison == Comparison.Is) c.Comparison = Comparison.Equals;
+
                 if(c.Comparison != Comparison.Equals)
                     throw new InvalidOperationException("Can't use a non-equality here");
 

--- a/SubSonic.Tests/BugReports/Update.cs
+++ b/SubSonic.Tests/BugReports/Update.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using SouthWind;
 using Xunit;
 using SubSonic;
 using SubSonic.Query;
@@ -76,6 +77,18 @@ namespace SubSonic.Tests.BugReports {
                 .Set("RequiredDate").EqualTo(new DateTime(2001, 12, 1));
 
             Assert.Contains("WHERE [Orders].[EmployeeID] < @0 AND [Orders].[OrderID] > @1", qry.GetCommand().CommandSql);
+        }
+
+        [Fact]
+        public void Github_Issue246_Update_Should_Support_Set_To_Null()
+        {
+            var provider = ProviderFactory.GetProvider("Northwind");
+            var qry = new Update<SouthWind.Category>(provider)
+                .Where(x => x.Picture == null)
+                .Set(x => x.Description == null);
+
+            Assert.Contains("SET [Categories].[Description]=@up_Description", qry.GetCommand().CommandSql);
+            Assert.Contains("WHERE [Categories].[Picture] IS NULL", qry.GetCommand().CommandSql);
         }
         
     }


### PR DESCRIPTION
Hi,

Now an InvalidOperationException is thrown with message
"Can't use a non-equality here" because the ' == null ' in a
Set is translated to IS NULL. This is correct in a Where statement,
but not in a Set statement.

Added one line of code to SubSonic.Query.Update which checks if a
Comparison.Is has been found. If so, it is changed to Comparison.Equals.

Also added a Unit Test to SubSonic.Tests.BugReports.Update

See issue 246 ( https://github.com/subsonic/SubSonic-3.0/issues/issue/246 )

The root of the problem is actually in QueryVisitor.VisitBinary(BinaryExpression b) where check is done to see whether a
Equal should be changed to an Is.

```
else if (b.NodeType == ExpressionType.Equal && current.ParameterValue == null)
{
     current.Comparison = Comparison.Is;
 }
```

In the case of a Set, this should not be done. I don't know if there's a way of knowing that the BinaryExpression is actually
part of a Set statement. In that case, the problem could be resolved in this part of the code.

Thx, Lieven Cardoen
