### PR TITLE
Fix: Output parameter size always set to 50

### DIFF
--- a/SubSonic.Core/Query/QueryCommand.cs
+++ b/SubSonic.Core/Query/QueryCommand.cs
@@ -268,6 +268,9 @@ namespace SubSonic.Query
                                            DataType = dbType
                                        };
 
+            if(maxSize > -1 )
+                param.Size = maxSize;
+
             parameters.Add(param);
         }
 


### PR DESCRIPTION
Fix: Output parameter size always set to 50
This was ignoring size set for output parameter and always set to 50 the default value. This cause problem for output parameter of type string.
